### PR TITLE
chore: Renombrar models a Models (Typo)

### DIFF
--- a/Backend/Models/Course.cs
+++ b/Backend/Models/Course.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Backend.models
+namespace Backend.Models
 {
     public class Course
     {

--- a/Backend/Models/CourseUser.cs
+++ b/Backend/Models/CourseUser.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Backend.models
+namespace Backend.Models
 {
     public class CourseUser
     {

--- a/Backend/Models/User.cs
+++ b/Backend/Models/User.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Backend.models
+namespace Backend.Models
 {
     public class User
     {


### PR DESCRIPTION
## Descripción

La carpeta y el namespace (models) tenía una typo estaba sin CamelCase, se cambió a Models.